### PR TITLE
fix dataset.py to work for both python2 and python3

### DIFF
--- a/aocr/model/model.py
+++ b/aocr/model/model.py
@@ -249,7 +249,6 @@ class Model(object):
             self.sess.run(tf.initialize_all_variables())
 
     def test(self):
-        loss = 0.0
         current_step = 0
         num_correct = 0.0
         num_total = 0.0
@@ -259,7 +258,6 @@ class Model(object):
             # Get a batch and make a step.
             start_time = time.time()
             result = self.step(batch, self.forward_only)
-            loss += result['loss'] / self.steps_per_checkpoint
             curr_step_time = (time.time() - start_time)
 
             if self.visualize:

--- a/aocr/model/model.py
+++ b/aocr/model/model.py
@@ -7,6 +7,7 @@ import time
 import os
 import math
 import logging
+import sys
 
 import distance
 import numpy as np
@@ -267,6 +268,9 @@ class Model(object):
 
             output = result['prediction']
             ground = batch['labels'][0]
+            if sys.version_info >= (3,):
+                output = output.decode('iso-8859-1')
+                ground = ground.decode('iso-8859-1')
 
             if self.use_distance:
                 incorrect = distance.levenshtein(output, ground)
@@ -278,7 +282,7 @@ class Model(object):
             num_correct += 1. - incorrect
 
             if self.visualize:
-                self.visualize_attention(batch['labels'][0], step_attns[0], output, ground, incorrect)
+                self.visualize_attention(ground, step_attns[0], output, ground, incorrect)
 
             step_accuracy = "{:>4.0%}".format(1. - incorrect)
             correctness = step_accuracy + (" ({} vs {})".format(output, ground) if incorrect else '')

--- a/aocr/util/data_gen.py
+++ b/aocr/util/data_gen.py
@@ -1,5 +1,6 @@
 import numpy as np
 import tensorflow as tf
+import sys
 
 from .bucketdata import BucketData
 from PIL import Image
@@ -71,8 +72,8 @@ class DataGen(object):
         self.clear()
 
     def convert_lex(self, lex):
-        # For Python 2/3 compatibility:
-        lex = str(lex)
+        if sys.version_info >= (3,):
+            lex = lex.decode('iso-8859-1')
 
         assert lex and len(lex) < self.bucket_specs[-1][1]
 

--- a/aocr/util/dataset.py
+++ b/aocr/util/dataset.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 import logging
 
-from six import text_type
+from six import b
 
 
 def _bytes_feature(value):
@@ -26,7 +26,7 @@ def generate(annotations_path, output_path, log_step=5000):
 
             example = tf.train.Example(features=tf.train.Features(feature={
                 'image': _bytes_feature(img),
-                'label': _bytes_feature(text_type.encode(label))}))
+                'label': _bytes_feature(b(label))}))
 
             writer.write(example.SerializeToString())
 


### PR DESCRIPTION
- properly use six.b() for creating an array of bytes (python3)
  or str (python2)
- without this, building datasets doesn't work with python2.
- more fixes for python3 bytes/string handling coming soon