### PR TITLE
add extra 2x1 pooling layer to compensate for same-padding

### DIFF
--- a/aocr/model/cnn.py
+++ b/aocr/model/cnn.py
@@ -138,6 +138,7 @@ class CNN(object):
         net = max_2x1pool(net, 'conv_pool4')
 
         net = ConvReluBN(net, 512, (2, 2), 'conv_conv7', is_training)
+        net = max_2x1pool(net, 'conv_pool5')
         net = dropout(net, is_training)
 
         net = tf.squeeze(net, axis=1)


### PR DESCRIPTION
- the original code was using valid-padding as a way to shrink
  the height from 2->1 in the last step of the cnn (but had the
  bad side effect of changing the width sometimes too). Using
  same-padding and this extra 2x1 pooling step fixes both.
- tested on training and testing