### PR TITLE
add some safety checks when creating datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ gcloud ml-engine jobs submit training $JOB_NAME \
 * `attn-use-lstm`: Whether or not use LSTM attention decoder cell.
 * `attn-num-hidden`: Number of hidden units in attention decoder cell.
 * `attn-num-layers`: Number of layers in attention decoder cell. (Encoder number of hidden units will be `attn-num-hidden`*`attn-num-layers`).
-* `target-vocab-size`: Target vocabulary size. Default is = 26+10+3 # 0: PADDING, 1: GO, 2: EOS, >2: 0-9, a-z
 * `no-resume`: Create new weights even if there are checkpoints present.
 * `max-gradient-norm`: Clip gradients to this norm.
 * `no-gradient-clipping`: Do not perform gradient clipping.

--- a/aocr/model/model.py
+++ b/aocr/model/model.py
@@ -278,7 +278,7 @@ class Model(object):
                 self.visualize_attention(ground, step_attns[0], output, ground, incorrect)
 
             step_accuracy = "{:>4.0%}".format(1. - incorrect)
-            correctness = step_accuracy + (" ({} vs {})".format(output, ground) if incorrect else '')
+            correctness = step_accuracy + (" ({} vs {})".format(output, ground) if incorrect else " (" + ground + ")")
 
             logging.info('Step {:.0f} ({:.3f}s). Accuracy: {:6.2%}, loss: {:f}, perplexity: {:0<7.6}. {}'.format(
                          current_step,

--- a/aocr/util/dataset.py
+++ b/aocr/util/dataset.py
@@ -18,14 +18,23 @@ def generate(annotations_path, output_path, log_step=5000, force_uppercase=True)
 
     writer = tf.python_io.TFRecordWriter(output_path)
 
+    longest_label = ''
+
     with open(annotations_path, 'r') as f:
         for idx, line in enumerate(f):
             (img_path, label) = line.rstrip('\n').split('\t', 1)
+            if not label:
+                logging.error('skipping image due to missing label %s', img_path)
+                continue
+
             with open(img_path, 'rb') as img_file:
                 img = img_file.read()
 
             if force_uppercase:
                 label = label.upper()
+
+            if len(label) > len(longest_label):
+                longest_label = label
 
             example = tf.train.Example(features=tf.train.Features(feature={
                 'image': _bytes_feature(img),
@@ -37,5 +46,6 @@ def generate(annotations_path, output_path, log_step=5000, force_uppercase=True)
                 logging.info('Processed %s pairs.', idx+1)
 
     logging.info('Dataset is ready: %i pairs.', idx+1)
+    logging.info('Longest label (%i): %s', len(longest_label), longest_label)
 
     writer.close()


### PR DESCRIPTION
- this saves time by detecting the problems earlier rather than later
- also tells you maximum length of input label, which is helpful
  for training runs
- output correct text in --test, to help show what's working and
  what's not