### PR TITLE
Bug/importer exporter

### DIFF
--- a/aocr/util/export.py
+++ b/aocr/util/export.py
@@ -37,6 +37,12 @@ class Exporter(object):
             if not os.path.exists(path):
                 os.makedirs(path)
 
+            self.output_graph_def = tf.graph_util.convert_variables_to_constants(
+                self.model.sess,
+                self.model.sess.graph.as_graph_def(),
+                ['prediction', 'probability'],
+            )
+
             with tf.gfile.GFile(path + '/frozen_graph.pb', "wb") as f:
                 f.write(self.output_graph_def.SerializeToString())
 

--- a/aocr/util/export.py
+++ b/aocr/util/export.py
@@ -4,58 +4,29 @@ import logging
 
 
 class Exporter(object):
-    def __init__(self, checkpoint_dir):
-        logging.info("Loading the checkpoint.")
-        checkpoint = tf.train.get_checkpoint_state(checkpoint_dir)
-        input_checkpoint = checkpoint.model_checkpoint_path
-        self.graph = tf.Graph()
-        with self.graph.as_default():
-            self.sess = tf.Session()
-            self.saver = tf.train.import_meta_graph(
-                input_checkpoint + '.meta',
-                clear_devices=True,
-            )
-            self.saver.restore(self.sess, input_checkpoint)
-
-            self.output_graph_def = tf.graph_util.convert_variables_to_constants(
-                self.sess,
-                tf.get_default_graph().as_graph_def(),
-                ['prediction'],
-            )
-        logging.info("Loaded the checkpoint from %s", checkpoint_dir)
+    def __init__(self, checkpoint_dir, model):
+        self.model = model
 
     def save(self, path, model_format):
-
         if model_format == "savedmodel":
-
             logging.info("Creating a SavedModel.")
 
-            with tf.Graph().as_default() as freezing_graph, tf.Session(config=tf.ConfigProto(allow_soft_placement=True)) as freezing_sess:
+            builder = tf.saved_model.builder.SavedModelBuilder(path)
+            freezing_graph=self.model.sess.graph
+            builder.add_meta_graph_and_variables(self.model.sess,
+                ["serve"],
+                signature_def_map={
+                    'serving_default': tf.saved_model.signature_def_utils.predict_signature_def(
+                        {'input': freezing_graph.get_tensor_by_name('input_image_as_bytes:0')},
+                        {
+                            'output': freezing_graph.get_tensor_by_name('prediction:0'),
+                            'probability': freezing_graph.get_tensor_by_name('probability:0')
+                        }
+                    ),
+                },
+                clear_devices=True)
 
-                tf.import_graph_def(
-                    self.output_graph_def,
-                    input_map=None,
-                    return_elements=None,
-                    op_dict=None,
-                    name="",
-                    producer_op_list=None
-                )
-
-                builder = tf.saved_model.builder.SavedModelBuilder(path)
-                builder.add_meta_graph_and_variables(freezing_sess,
-                    ["serve"],
-                    signature_def_map={
-                        'serving_default': tf.saved_model.signature_def_utils.predict_signature_def(
-                            {'input': freezing_graph.get_tensor_by_name('input_image_as_bytes:0')},
-                            {
-                                'output': freezing_graph.get_tensor_by_name('prediction:0'),
-                                'probability': freezing_graph.get_tensor_by_name('probability:0')
-                            }
-                        ),
-                    },
-                    clear_devices=True)
-
-                builder.save()
+            builder.save()
 
             logging.info("Exported SavedModel into %s", path)
 


### PR DESCRIPTION
Fix exporting to use a dynamically created model so that we don't include dropout or anything like that. This addresses #25 and some conversation from #34. 

NOTE: In `frozengraph` export, we no longer "clear devices". I think there's a way to do this using tf.train.saver, but I don't use frozengraphs so i don't know how to test that. opening that piece up to the community if someone has more experience there