### PR TITLE
command-line parser errors out on unknown arguments

### DIFF
--- a/aocr/__main__.py
+++ b/aocr/__main__.py
@@ -247,7 +247,7 @@ def process_args(args, defaults):
                               (defaults.CLIP_GRADIENTS)))
     parser.set_defaults(clip_gradients=defaults.CLIP_GRADIENTS)
 
-    parameters, _ = parser.parse_known_args(args)
+    parameters, _ = parser.parse_args(args)
     return parameters
 
 


### PR DESCRIPTION
- the old way was just masking errors
- fixes #39