### PR TITLE
correct parse_args usage

### DIFF
--- a/aocr/__main__.py
+++ b/aocr/__main__.py
@@ -247,7 +247,7 @@ def process_args(args, defaults):
                               (defaults.CLIP_GRADIENTS)))
     parser.set_defaults(clip_gradients=defaults.CLIP_GRADIENTS)
 
-    parameters, _ = parser.parse_args(args)
+    parameters = parser.parse_args()
     return parameters
 
 

--- a/aocr/__main__.py
+++ b/aocr/__main__.py
@@ -247,7 +247,7 @@ def process_args(args, defaults):
                               (defaults.CLIP_GRADIENTS)))
     parser.set_defaults(clip_gradients=defaults.CLIP_GRADIENTS)
 
-    parameters = parser.parse_args()
+    parameters = parser.parse_args(args)
     return parameters
 
 


### PR DESCRIPTION
`parser.parse_args` only returns one value and doesn't require an input. Current implementation crashes at this point.