### PR TITLE
fix parsing dataset input lines

### DIFF
--- a/aocr/util/dataset.py
+++ b/aocr/util/dataset.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+import re
 
 import tensorflow as tf
 
@@ -28,11 +29,14 @@ def generate(annotations_path, output_path, log_step=5000,
     with open(annotations_path, 'r') as annotations:
         for idx, line in enumerate(annotations):
             line = line.rstrip('\n')
-            try:
-                (img_path, label) = line.split(None, 1)
-            except ValueError:
+
+            # Split the line on the first whitespace character and allow empty values for the label
+            # NOTE: this does not allow whitespace in image paths
+            line_match = re.match(r'(\S+)\s(.*)', line)
+            if line_match is None:
                 logging.error('missing filename or label, ignoring line %i: %s', idx+1, line)
                 continue
+            (img_path, label) = line_match.groups()
 
             with open(img_path, 'rb') as img_file:
                 img = img_file.read()


### PR DESCRIPTION
Fixes #100. This would restore original functionality before https://github.com/emedvedev/attention-ocr/commit/0cfeacb945f78e810ebac587ab06a67e7da9d752 and still allow any singular whitespace separator between the image path and the label.

The only downside to this method is it doesn't allow whitespace in image paths. My recommendation if this is desired is to switch the code back to only allowing tabs, or changing over to a json format.