### PR TITLE
Fix bug of issue#86 and issue#131

### DIFF
--- a/aocr/model/model.py
+++ b/aocr/model/model.py
@@ -133,7 +133,7 @@ class Model(object):
             self.target_weights = []
             for i in xrange(self.decoder_size + 1):
                 self.decoder_inputs.append(
-                    tf.tile([0], [num_images])
+                    tf.tile([1], [num_images])
                 )
                 if i < self.decoder_size:
                     self.target_weights.append(tf.tile([1.], [num_images]))


### PR DESCRIPTION
First of all, you define `GO` flag's index as 1 in `data_gen.py`:
```python
class DataGen(object):
    GO_ID = 1
    EOS_ID = 2
    IMAGE_HEIGHT = 32
    CHARMAP = ['', '', ''] + list('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ')
```
Second,  `decoder_inputs` will be filled with value 0 in `model.py`:
```python
self.decoder_inputs = []
self.target_weights = []
for i in xrange(self.decoder_size + 1):
    self.decoder_inputs.append(
        tf.tile([0], [num_images])
    )
```
In train mode, it is ok because `decoder_inputs` will be filled with ground truth labels, but in predict mode, first element of `decoder_inputs` will be 0, and it is not the correct index for `GO` flag.